### PR TITLE
editor: stop Pylance parsing .rpy files (workspace setting)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
-{
-    "files.exclude": {
-        "**/*.rpyc": true,
-        "**/*.rpa": true,
-        "**/*.rpymc": true,
-        "**/cache/": true
-    }
+﻿{
+  "files.associations": {
+    "*.rpy": "plaintext"
+  },
+  "python.analysis.exclude": [
+    "**/*.rpy"
+  ]
 }


### PR DESCRIPTION
Treat .rpy files as plaintext in editor settings to avoid Pylance producing false-positive Python syntax errors for Ren'Py scripts.