### PR TITLE
chore: fix markdown lint issues (README, CONTRIBUTING, BUILD)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,21 @@
+<!-- Clean CONTRIBUTING.md for linters: single H1, ATX headings, fixed terminology -->
+
 # Contributing to The Marooned's Folly
 
 Thank you for helping improve the game! This document describes the recommended workflow, branch naming, pull request (PR) process, and how the repository's automation behaves.
 
-Basics
+## Basics
 
 - Fork or clone the repository and create a branch for each separate change.
 - Keep changes small and focused. One feature or bugfix per branch/PR.
 
-Branch naming
+## Branch naming
 
 - Use this pattern for feature branches: `feature/<short-description>`
 - For fixes/bugs: `fix/<short-description>`
 - For experiments or spikes: `wip/<topic>`
 
-Workflow (recommended)
+## Workflow (recommended)
 
 1. Update your local main: `git checkout main ; git pull origin main`
 2. Create a branch: `git checkout -b feature/my-feature`
@@ -22,78 +24,33 @@ Workflow (recommended)
 5. Push: `git push -u origin feature/my-feature`
 6. Open a Pull Request on GitHub targeting `main`.
 
-Pull request guidelines
+## Pull request guidelines
 
 - Include a short description of the change and the motivation.
 - Link any related issues (if applicable).
 - Provide testing notes: how to run and what to verify.
 - Request reviewers and wait for at least one approving review before merging.
 
-Automation & auto-PR behavior
+## Automation & auto-PR behavior
 
 - If you push a branch named `feature/**`, a GitHub Actions workflow will automatically create a PR targeting `main` if one doesn't exist. This makes iteration faster for small features.
 - Labeling a PR with `automerge` will cause the auto-merge workflow to squash-merge the PR once requirements (reviews, checks) pass.
 
-When automation might fail
+## When automation might fail
 
 - The workflows use the built-in `GITHUB_TOKEN` by default, which may be restricted by organization or repository settings. If automatic PR creation or merging fails, a repository secret named `PR_TOKEN` (a Personal Access Token with `repo` scope) can be added by a maintainer to enable the automation.
 
-Code style & testing
+## Code style & testing
 
 - Keep code and scripts readable. There are no formal linters configured in this repository; run manual checks when appropriate.
 - Test your changes by launching the game locally and verifying the affected scenes or features.
 
-Adding assets
+## Adding assets
 
 - Keep large binary assets out of the main git history. Use Git LFS for very large files or provide download links in the repository.
 
-Maintainers
+## Maintainers
 
-- Maintainers will review incoming PRs and merge when ready. If you're a maintainer and want to change the automation or branch protections, update the `.github/workflows/` files and repository branch protection rules.
-
-Thanks for contributing! If you're unsure about where to start, open an issue or a draft PR and ask for guidance.
-# Contributing to The Marooned's Folly
-
-Thank you for helping improve the game! This document describes the recommended workflow, branch naming, pull request (PR) process, and how the repository's automation behaves.
-
-Basics
-- Fork or clone the repository and create a branch for each separate change.
-- Keep changes small and focused. One feature or bugfix per branch/PR.
-
-Branch naming
-- Use this pattern for feature branches: `feature/<short-description>`
-- For fixes/bugs: `fix/<short-description>`
-- For experiments or spikes: `wip/<topic>`
-
-Workflow (recommended)
-1. Update your local main: `git checkout main ; git pull origin main`
-2. Create a branch: `git checkout -b feature/my-feature`
-3. Make changes and run the game locally (see `docs/BUILD.md`).
-4. Commit with a clear message: `git add . ; git commit -m "Short summary: what and why"`
-5. Push: `git push -u origin feature/my-feature`
-6. Open a Pull Request on GitHub targeting `main`.
-
-Pull request guidelines
-- Include a short description of the change and the motivation.
-- Link any related issues (if applicable).
-- Provide testing notes: how to run and what to verify.
-- Request reviewers and wait for at least one approving review before merging.
-
-Automation & auto-PR behavior
-- If you push a branch named `feature/**`, a GitHub Actions workflow will automatically create a PR targeting `main` if one doesn't exist. This makes iteration faster for small features.
-- Labeling a PR with `automerge` will cause the auto-merge workflow to squash-merge the PR once requirements (reviews, checks) pass.
-
-When automation might fail
-- The workflows use the builtin `GITHUB_TOKEN` by default, which may be restricted by organization or repo settings. If automatic PR creation or merging fails, a repository secret named `PR_TOKEN` (a Personal Access Token with `repo` scope) can be added by a maintainer to enable the automation.
-
-Code style & testing
-- Keep code and scripts readable. There are no formal linters configured in this repo; run manual checks when appropriate.
-- Test your changes by launching the game locally and verifying the affected scenes or features.
-
-Adding assets
-- Keep large binary assets out of the main git history. Use Git LFS for very large files or provide download links in the repo.
-
-Maintainers
 - Maintainers will review incoming PRs and merge when ready. If you're a maintainer and want to change the automation or branch protections, update the `.github/workflows/` files and repository branch protection rules.
 
 Thanks for contributing! If you're unsure about where to start, open an issue or a draft PR and ask for guidance.

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -2,45 +2,32 @@
 
 This document shows how to run the game from the Ren'Py SDK and how to build distributable packages. The instructions focus on Windows (PowerShell), with brief notes for macOS and Linux.
 
-Prerequisites
-- Ren'Py SDK downloaded and extracted. You can download it from https://www.renpy.org/
-- (Optional) Git if you want to pull the latest source or use version control.
+## Prerequisites
 
-Run the game from the Ren'Py SDK (Windows PowerShell)
-1. Open PowerShell.
-2. Change to the Ren'Py SDK folder (where `renpy.exe` lives) or the SDK launcher folder.
-
-```powershell
-# Building and running The Marooned's Folly (Ren'Py)
-
-This document shows how to run the game from the Ren'Py SDK and how to build distributable packages. The instructions focus on Windows (PowerShell), with brief notes for macOS and Linux.
-
-Prerequisites
-
-- Ren'Py SDK downloaded and extracted. You can download it from the Ren'Py website: [https://www.renpy.org/](https://www.renpy.org/).
+- Ren'Py SDK downloaded and extracted. You can download it from the Ren'Py website: [Ren'Py](https://www.renpy.org/).
 - (Optional) Git if you want to pull the latest source or use version control: [Git downloads](https://git-scm.com/downloads).
 
-Run the game from the Ren'Py SDK (Windows PowerShell)
+## Run the game from the Ren'Py SDK (Windows PowerShell)
 
 1. Open PowerShell.
-2. Change to the Ren'Py SDK folder (where `renpy.exe` lives) or the SDK launcher folder.
+2. Change to the Ren'Py SDK folder (where `renpy.exe` lives) or the SDK launcher folder:
 
-```powershell
-cd "e:\renpy-8.4.1-sdk"
-```
+   ```powershell
+   cd "e:\renpy-8.4.1-sdk"
+   ```
 
 3. Launch the Ren'Py launcher and select this project, or run the project directly using the CLI:
 
-```powershell
-# Show the projects and launcher UI
-& .\renpy.exe
-# OR run the project directly by passing the project directory name (folder with `game/`)
-& .\renpy.exe "e:\renpy-8.4.1-sdk\The-Marooneds-Folly"
-```
+   ```powershell
+   # Show the projects and launcher UI
+   & .\renpy.exe
+   # OR run the project directly by passing the project directory name (folder with `game/`)
+   & .\renpy.exe "e:\renpy-8.4.1-sdk\The-Marooneds-Folly"
+   ```
 
 4. The Ren'Py launcher opens. Click 'Launch Project' (or use the CLI command above) to start the game.
 
-Run quickly without the launcher (Python/CLI)
+## Run quickly without the launcher (Python/CLI)
 
 If you prefer running the game directly (fast, for development), run the project's `renpy.py` with the SDK's Python. This is useful for automated tests or headless runs.
 
@@ -49,24 +36,24 @@ If you prefer running the game directly (fast, for development), run the project
 python .\renpy.py launch "e:\renpy-8.4.1-sdk\The-Marooneds-Folly"
 ```
 
-Build distributables (Windows PowerShell)
+## Build distributables (Windows PowerShell)
 
 1. Open PowerShell and change to the Ren'Py SDK root:
 
-```powershell
-cd "e:\renpy-8.4.1-sdk"
-```
+   ```powershell
+   cd "e:\renpy-8.4.1-sdk"
+   ```
 
 2. Use the build command to create distributions (Windows, macOS, Linux). Replace <project-dir> with the path to the folder that contains `game/` (this repo):
 
-```powershell
-# Example: build distributions for the project
-& .\renpy.exe build "e:\renpy-8.4.1-sdk\The-Marooneds-Folly"
-```
+   ```powershell
+   # Example: build distributions for the project
+   & .\renpy.exe build "e:\renpy-8.4.1-sdk\The-Marooneds-Folly"
+   ```
 
 3. When the build finishes, check the `dist/` subfolder inside the Ren'Py SDK root (or the `dist/` folder specified in the Ren'Py launcher) for platform-specific packages (zip/exe/dmg).
 
-Notes and tips
+## Notes and tips
 
 - Use the Ren'Py launcher GUI when you want visual control over translations, package name, or when adding icons.
 - Windows: If `renpy.exe` doesn't run double-check that the SDK is the correct edition for your OS and that you have Visual C++ redistributables if needed.
@@ -74,9 +61,9 @@ Notes and tips
 - For CI: you can run the renpy build CLI inside a CI job — ensure the CI runner has the SDK and required system packages. Consider caching the SDK between runs.
 - Large assets: use .gitignore / Git LFS for very large files.
 
-Troubleshooting
+## Troubleshooting
 
 - Game fails to start: check `game/log.txt`, `log.txt` in the repository root, and Ren'Py output in the launcher for Python errors or missing assets.
 - Build errors: missing dependencies or permission issues; run the launcher once interactively to ensure all resources load correctly.
 
-If you'd like, I can add a short `Makefile`-style PowerShell script or a small `build.ps1` under `tools/` to wrap these commands for repeatable local builds.
+If you'd like, I can add a short PowerShell wrapper script (for example `tools/build.ps1`) to make these commands repeatable.


### PR DESCRIPTION
Run Super-Linter after cleaning README, CONTRIBUTING, and BUILD.md for markdownlint/textlint issues.